### PR TITLE
elasticsearch-node-stats

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cauchy-jobs-elasticsearch "0.1.1"
+(defproject cauchy-jobs-elasticsearch "0.1.2"
   :description "Cauchy jobs to monitor Elasticsearch server"
   :url "https://github.com/pguillebert/cauchy-jobs-elasticsearch"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cauchy-jobs-elasticsearch "0.1.0"
+(defproject cauchy-jobs-elasticsearch "0.1.1"
   :description "Cauchy jobs to monitor Elasticsearch server"
   :url "https://github.com/pguillebert/cauchy-jobs-elasticsearch"
   :scm {:name "git"

--- a/src/cauchy/jobs/elasticsearch.clj
+++ b/src/cauchy/jobs/elasticsearch.clj
@@ -88,15 +88,15 @@
         {:service "indices.search.query_current" :metric (get-in node-stats [:indices :search :query_current])}
         {:service "indices.search.open_contexts" :metric (get-in node-stats [:indices :search :open_contexts])}
         ;;Node jvm heap metrics
-        {:service "heap.used_bytes" :metric (get-in node-stats [:jvm :mem :heap_used_in_bytes])}
-        {:service "heap.used_pct" :metric (get-in node-stats [:jvm :mem :heap_used_percent])}
-        {:service "heap.max_bytes" :metric (get-in node-stats [:jvm :mem :heap_max_in_bytes])}
-        {:service "non_heap.used_bytes" :metric (get-in node-stats [:jvm :mem :non_heap_used_in_bytes])}
+        {:service "jvm.heap.used_bytes" :metric (get-in node-stats [:jvm :mem :heap_used_in_bytes])}
+        {:service "jvm.heap.used_pct" :metric (get-in node-stats [:jvm :mem :heap_used_percent])}
+        {:service "jvm.heap.max_bytes" :metric (get-in node-stats [:jvm :mem :heap_max_in_bytes])}
+        {:service "jvm.non_heap.used_bytes" :metric (get-in node-stats [:jvm :mem :non_heap_used_in_bytes])}
         ;;Node jvm gc metrics
-        {:service "gc.young.count" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_count])}
-        {:service "gc.young.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_time_in_millis])}
-        {:service "gc.old.count" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_count])}
-        {:service "gc.old.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_time_in_millis])}
+        {:service "jvm.gc.young.count" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_count])}
+        {:service "jvm.gc.young.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_time_in_millis])}
+        {:service "jvm.gc.old.count" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_count])}
+        {:service "jvm.gc.old.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_time_in_millis])}
         ]
         ;;Thread data
         (mapcat

--- a/src/cauchy/jobs/elasticsearch.clj
+++ b/src/cauchy/jobs/elasticsearch.clj
@@ -87,7 +87,12 @@
         {:service "indices.search.query_total" :metric (get-in node-stats [:indices :search :query_total])}
         {:service "indices.search.query_current" :metric (get-in node-stats [:indices :search :query_current])}
         {:service "indices.search.open_contexts" :metric (get-in node-stats [:indices :search :open_contexts])}
-        ;;Node jvm metrics
+        ;;Node jvm heap metrics
+        {:service "heap.used_bytes" :metric (get-in node-stats [:jvm :mem :heap_used_in_bytes])}
+        {:service "heap.used_pct" :metric (get-in node-stats [:jvm :mem :heap_used_percent])}
+        {:service "heap.max_bytes" :metric (get-in node-stats [:jvm :mem :heap_max_in_bytes])}
+        {:service "non_heap.used_bytes" :metric (get-in node-stats [:jvm :mem :non_heap_used_in_bytes])}
+        ;;Node jvm gc metrics
         {:service "gc.young.count" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_count])}
         {:service "gc.young.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_time_in_millis])}
         {:service "gc.old.count" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_count])}

--- a/src/cauchy/jobs/elasticsearch.clj
+++ b/src/cauchy/jobs/elasticsearch.clj
@@ -56,23 +56,54 @@
                  initializing_shards active_primary_shards]
           :as health} (fetch-health conf)
          stats (fetch-stats conf)]
-     [{:service "color" :state (color->state status)}
-
+     [
+      ;;Cluster metrics
+      {:service "color" :state (color->state status)}
       {:service "local_active_shards"
        :metric (count-local-active-shards conf)}
-
       {:service "docs_in_cluster"
        :metric (get-in stats [:_all :primaries :docs :count])}
-
       {:service "fielddata_memory_size_in_bytes"
        :metric (get-in stats [:_all :total :fielddata :memory_size_in_bytes])}
-
       {:service "fielddata_evictions"
        :metric (get-in stats [:_all :total :fielddata :evictions])}
-
       {:service "active_shards" :metric active_shards}
       {:service "unassigned_shards" :metric unassigned_shards}
       {:service "relocating_shards" :metric relocating_shards}
       {:service "initializing_shards" :metric initializing_shards}
-      {:service "active_primary_shards" :metric active_primary_shards}]))
+      {:service "active_primary_shards" :metric active_primary_shards}
+      ]))
   ([] (elasticsearch-health {})))
+
+(defn elasticsearch-node-stats
+    ([{:keys [host port] :as conf}]
+      (let [ [node-id node-stats] (first (get-in (fetch-local conf) [:nodes]))]
+        (vec (concat [
+        ;;Node indices metrics
+        {:service "indices.indexing.total" :metric (get-in node-stats [:indices :indexing :index_total])}
+        {:service "indices.indexing.current" :metric (get-in node-stats [:indices :indexing :index_current])}
+        {:service "indices.get.total" :metric (get-in node-stats [:indices :get :total])}
+        {:service "indices.get.current" :metric (get-in node-stats [:indices :get :current])}
+        {:service "indices.search.query_total" :metric (get-in node-stats [:indices :search :query_total])}
+        {:service "indices.search.query_current" :metric (get-in node-stats [:indices :search :query_current])}
+        {:service "indices.search.open_contexts" :metric (get-in node-stats [:indices :search :open_contexts])}
+        ;;Node jvm metrics
+        {:service "gc.young.count" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_count])}
+        {:service "gc.young.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :young :collection_time_in_millis])}
+        {:service "gc.old.count" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_count])}
+        {:service "gc.old.collection_time_in_millis" :metric (get-in node-stats [:jvm :gc :collectors :old :collection_time_in_millis])}
+        ]
+        ;;Thread data
+        (mapcat
+          (fn [[thread_type thread_data]]
+            [{ :service (str "thread_pool." (name thread_type) ".nb") :metric (get-in thread_data [:threads]) }
+            { :service (str "thread_pool." (name thread_type) ".queue") :metric (get-in thread_data [:queue]) }
+            { :service (str "thread_pool." (name thread_type) ".completed") :metric (get-in thread_data [:completed]) }
+            { :service (str "thread_pool." (name thread_type) ".largest") :metric (get-in thread_data [:largest]) }
+            ]
+          ) (get-in node-stats [:thread_pool])
+        )
+        ))
+      ))
+  ([] (elasticsearch-node-stats {}))
+)


### PR DESCRIPTION
Add job function to monitor basic indices, gc and thread metrics on the local nodes.
